### PR TITLE
Reprioritize profile README to surface Rust/WASM and auth work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # Hi there 👋
 
-I'm **Shogo Tsuneto**, a software engineer passionate about **Event Sourcing**, **CQRS**, and **modern microservices architecture**. My repositories focus on building clean, minimal, and extensible tools for event-driven systems and schema-first development.
+I'm **Shogo Tsuneto**, a software engineer interested in **modern microservices architecture**, **schema-first development**, and building clean, minimal, and extensible tools across the stack.
+
+## 🦀 Rust & WebAssembly
+
+Exploring modern frontend development with Rust:
+
+### [pomodoro-leptos-csr](https://github.com/shogotsuneto/pomodoro-leptos-csr)
+A Pomodoro timer that runs entirely in the browser, built with the [Leptos](https://leptos.dev/) framework (client-side rendering) and compiled to WebAssembly. Features work/break cycles with auto-start, configurable durations, task attribution, session history, and in-flight session persistence via IndexedDB. Built and deployed to GitHub Pages with Trunk. **[Live app →](https://shogotsuneto.github.io/pomodoro-leptos-csr/)**
+
+## 🔐 Authentication & API Tooling
+
+Tools for modern API development, testing, and identity:
+
+### [jwks-mock-api](https://github.com/shogotsuneto/jwks-mock-api)
+A lightweight mock JSON Web Key Set (JWKS) service for backend API development and testing. Single binary (~10MB) with dynamic JWT claims, multiple keys support, and OAuth 2.0 token introspection — useful for exercising JWKS and OAuth 2.0 flows without a full identity provider.
+
+### [simple-query-server](https://github.com/shogotsuneto/simple-query-server)
+A lightweight server with YAML-based configuration for database connections and query definitions. Create read-only database APIs without writing custom code for each query.
 
 ## 🎯 Event Sourcing & CQRS
 
@@ -15,26 +32,9 @@ Minimal in-memory event-sourced state management for Go with clean State interfa
 ### [go-simple-es-projector](https://github.com/shogotsuneto/go-simple-es-projector)
 A minimal event worker that repeatedly pulls events from an event source and invokes user-provided projection logic. Users control checkpoint storage and transactional atomicity.
 
-### [simple-query-server](https://github.com/shogotsuneto/simple-query-server)
-A lightweight Go server with YAML-based configuration for database connections and query definitions. Create read-only database APIs without writing custom code for each query.
-
 ## 🎭 Dapr Actor Model
 
-Schema-first development tools and patterns for building distributed actor systems:
+Schema-first tooling for distributed actor systems:
 
-### [dapr-actor-gen](https://github.com/shogotsuneto/dapr-actor-gen)
-A standalone code generator for creating Go interfaces, types, and factory functions from OpenAPI 3.0 specifications for Dapr actors. Enables schema-first development with type-safe code generation.
-
-### [dapr-actor-experiment](https://github.com/shogotsuneto/dapr-actor-experiment)
-A comprehensive demo of Dapr actors demonstrating state management, method invocation patterns, and CQRS architecture. Features authentication middleware, multiple actor types, and complete Docker setup.
-
-## 🛠️ Developer Tools
-
-Utilities for modern API development and testing:
-
-### [jwks-mock-api](https://github.com/shogotsuneto/jwks-mock-api)
-A lightweight mock JSON Web Key Set (JWKS) service for backend API development and testing. Single binary (~10MB) with dynamic JWT claims, multiple keys support, and OAuth 2.0 token introspection.
-
----
-
-💡 **These repositories work together** to provide a complete toolkit for building event-sourced microservices with Dapr, from foundational event stores to complete applications with authentication.
+- **[dapr-actor-gen](https://github.com/shogotsuneto/dapr-actor-gen)** — Code generator producing Go interfaces and types from OpenAPI 3.0 specs for Dapr actors.
+- **[dapr-actor-experiment](https://github.com/shogotsuneto/dapr-actor-experiment)** — Demo of Dapr actors covering state management, method invocation, and CQRS.


### PR DESCRIPTION
## Summary
Reorders the profile README to reflect current focus areas.

- **Rust & WebAssembly** is now the top section, leading with `pomodoro-leptos-csr` (Leptos CSR + WASM, with a live app link) — the most recent project.
- **Authentication & API Tooling** moved up, highlighting `jwks-mock-api` as a signal of JWKS / OAuth 2.0 experience.
- **Event Sourcing & CQRS** (Go) demoted toward the bottom, as it's a lower current priority.
- **Dapr Actor Model** compacted to a brief two-item list and placed last.
- Reworded the intro to be less Event-Sourcing-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)